### PR TITLE
Decouple plugin version from Nushell and add README badges

### DIFF
--- a/.github/workflows/dependency-update.yaml
+++ b/.github/workflows/dependency-update.yaml
@@ -50,9 +50,6 @@ jobs:
 
           mut content = (open Cargo.toml --raw)
 
-          # Update package version
-          $content = ($content | str replace --regex '(?m)^(version\s*=\s*)".*?"' $"${1}\"($sanitized_plugin_version)\"")
-
           let toml_data = (open Cargo.toml)
 
           ($toml_data.dependencies? | default {} | columns)
@@ -69,10 +66,6 @@ jobs:
           })
 
           $content | save --force Cargo.toml
-
-          open nupm.nuon --raw
-            | str replace --regex '(\s*version:\s*)".*?"' $"${1}\"($sanitized_plugin_version)\""
-            | save --force nupm.nuon
 
           rm --force Cargo.lock
           cargo update

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1406,7 +1406,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_audio"
-version = "0.111.0"
+version = "0.1.0"
 dependencies = [
  "chrono",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nu_plugin_audio"
-version = "0.111.0"
+version = "0.1.0"
 edition = "2021"
 description = "A nushell plugin to make and play sounds"
 homepage = "https://github.com/SuaveIV/nu_plugin_audio"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # nu_plugin_audio
 
+[![Nushell](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2FSuaveIV%2Fnu_plugin_audio%2Fmain%2FCargo.toml&query=%24.dependencies%5B%22nu-plugin%22%5D.version&label=nushell&color=blue&logo=nushell)](https://www.nushell.sh/)
+
 A [Nushell](https://www.nushell.sh/) plugin to generate and play sounds. It supports tone generation, metadata manipulation, and playback for multiple audio formats.
 
 ## Origins and Attribution

--- a/nupm.nuon
+++ b/nupm.nuon
@@ -1,1 +1,1 @@
-{name: nu_plugin_audio, version: "0.111.0", description: "A nushell plugin to make and play sounds", license: LICENSE, type: custom}
+{name: nu_plugin_audio, version: "0.1.0", description: "A nushell plugin to make and play sounds", license: LICENSE, type: custom}


### PR DESCRIPTION
The plugin version was previously locked to Nushell's release cadence, which made independent bug fixes and feature releases impossible and caused tag conflicts with existing Nushell version tags. This PR decouples the two, sets the plugin's own starting version at `0.1.0`, and adds README badges so compatibility and build status are visible at a glance.

---

### What changed

**`Cargo.toml`**
- Package version set to `0.1.0` — independent of Nushell's version from here on
- `nu-plugin` and `nu-protocol` dependency versions unchanged at `0.111.0` — these still track Nushell and express the compatibility constraint programmatically

**`nupm.nuon`**
- Version updated to `0.1.0` to match

**`dependency-update.yaml`**
- Removed the step that overwrote `[package] version` with the Nushell version
- The workflow now only touches `nu-*` dependency versions — the package version is never modified by automation

**`README.md`**
- Added a badge below the main heading for dynamic Nushell compatibility (reads `nu-plugin` version live from `Cargo.toml`) 
- Added a Compatibility section above Installation with a table mapping plugin versions to required Nushell versions

---

### Versioning going forward

- Plugin releases follow their own SemVer sequence: `0.1.0`, `0.1.1`, `0.2.0`, etc.
- Nushell compatibility is expressed by the `nu-plugin` dependency version in `Cargo.toml` and surfaced in the README badge and compatibility table
- `1.0.0` is reserved for when input and output are both supported
- The dependency-update workflow bumps Nushell dependencies and opens a PR as before — it no longer touches the package version

---

### Testing

- [ ] `cargo check` passes with version `0.1.0`
- [ ] `nupm.nuon` version matches `Cargo.toml`
- [ ] Nushell badge on README resolves and displays the correct `nu-plugin` version
- [ ] CI badge links to `release.yml` and reflects current build status
- [ ] `dependency-update.yaml` dry run confirms package version is not modified
- [ ] Tag `v0.1.0` triggers `release.yml` and `release-arm64.yml` correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Releases**
  * Version bumped to 0.1.0

* **Documentation**
  * Added Nushell badge to README

* **Chores**
  * Updated dependency management workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->