### PR TITLE
security: add build provenance attestation to ARM64 release artifacts

### DIFF
--- a/.github/workflows/release-arm64.yml
+++ b/.github/workflows/release-arm64.yml
@@ -1,10 +1,5 @@
 name: Release ARM64
 
-permissions:
-  contents: write
-  attestations: write
-  id-token: write
-
 on:
   workflow_dispatch:
     inputs:
@@ -18,6 +13,10 @@ on:
 jobs:
   build-arm64:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      attestations: write
+      id-token: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       TAG: ${{ github.event.inputs.tag || github.ref_name }}
@@ -64,6 +63,10 @@ jobs:
             echo "Attempt $i/90: waiting..."
             sleep 10
           done
+      - name: Attest
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: "nu_plugin_audio-${{ env.TAG }}-aarch64-unknown-linux-gnu.tar.gz"
       - name: Upload to Release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
@@ -71,7 +74,3 @@ jobs:
             nu_plugin_audio-${{ env.TAG }}-aarch64-unknown-linux-gnu.tar.gz
             nu_plugin_audio-${{ env.TAG }}-aarch64-unknown-linux-gnu.tar.gz.sha256
           tag_name: ${{ env.TAG }}
-      - name: Attest
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
-        with:
-          subject-path: "nu_plugin_audio-${{ env.TAG }}-aarch64-unknown-linux-gnu.tar.gz"


### PR DESCRIPTION
The ARM64 tarball was the only release artifact without provenance attached. This was noticed during the SHA-pinning work but left out of that PR to keep scope tight.

The fix is small — `attestations: write` and `id-token: write` added to the top-level permissions block, and an attest step after the upload using the same `actions/attest-build-provenance` SHA already in use in `release.yml` and `dist-workspace.toml`.

Closes #13 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added build provenance attestation for ARM64 releases to cryptographically verify release artifacts.
  * Updated release workflow permissions to a per-job scope to enable attestation and related write operations while narrowing top-level access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->