### PR TITLE
fix(ci): resolve tag from API instead of workflow_run context

### DIFF
--- a/.github/workflows/release-arm64.yml
+++ b/.github/workflows/release-arm64.yml
@@ -21,18 +21,24 @@ jobs:
       id-token: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      TAG: ${{ github.event.inputs.tag || github.event.workflow_run.head_branch || github.ref_name }}
       PKG_CONFIG_SYSROOT_DIR: /usr/lib/aarch64-linux-gnu
     steps:
-      - name: Validate tag format
+      - name: Resolve and validate tag
+        id: resolve-tag
         run: |
-          if [[ ! "${{ env.TAG }}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$ ]]; then
+          if [[ -n "${{ github.event.inputs.tag }}" ]]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            TAG=$(gh api "repos/${{ github.repository }}/releases/latest" --jq '.tag_name')
+          fi
+          if [[ ! "$TAG" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$ ]]; then
             echo "Error: Invalid tag format"
             exit 1
           fi
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ env.TAG }}
+          ref: ${{ steps.resolve-tag.outputs.tag }}
           persist-credentials: false
           submodules: recursive
       - name: Install cross
@@ -42,17 +48,17 @@ jobs:
       - name: Package
         run: |
           tar -czf \
-            "nu_plugin_audio-${{ env.TAG }}-aarch64-unknown-linux-gnu.tar.gz" \
+            "nu_plugin_audio-${{ steps.resolve-tag.outputs.tag }}-aarch64-unknown-linux-gnu.tar.gz" \
             -C target/aarch64-unknown-linux-gnu/release nu_plugin_audio
       - name: Checksum
         run: |
-          sha256sum "nu_plugin_audio-${{ env.TAG }}-aarch64-unknown-linux-gnu.tar.gz" \
-            > "nu_plugin_audio-${{ env.TAG }}-aarch64-unknown-linux-gnu.tar.gz.sha256"
+          sha256sum "nu_plugin_audio-${{ steps.resolve-tag.outputs.tag }}-aarch64-unknown-linux-gnu.tar.gz" \
+            > "nu_plugin_audio-${{ steps.resolve-tag.outputs.tag }}-aarch64-unknown-linux-gnu.tar.gz.sha256"
       - name: Wait for main release
         run: |
-          echo "Waiting for main release to be published for tag ${{ env.TAG }}"
+          echo "Waiting for main release to be published for tag ${{ steps.resolve-tag.outputs.tag }}"
           for i in {1..90}; do
-            DRAFT=$(gh api "repos/${{ github.repository }}/releases/tags/${{ env.TAG }}" \
+            DRAFT=$(gh api "repos/${{ github.repository }}/releases/tags/${{ steps.resolve-tag.outputs.tag }}" \
               --jq '.draft' 2>/dev/null || echo "notfound")
             if [ "$DRAFT" = "false" ]; then
               echo "Release is published, proceeding"
@@ -68,11 +74,11 @@ jobs:
       - name: Attest
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
-          subject-path: "nu_plugin_audio-${{ env.TAG }}-aarch64-unknown-linux-gnu.tar.gz"
+          subject-path: "nu_plugin_audio-${{ steps.resolve-tag.outputs.tag }}-aarch64-unknown-linux-gnu.tar.gz"
       - name: Upload to Release
         uses: softprops/action-gh-release@26e8ad27a09a225049a7075d7ec1caa2df6ff332 # v2.6.0
         with:
           files: |
-            nu_plugin_audio-${{ env.TAG }}-aarch64-unknown-linux-gnu.tar.gz
-            nu_plugin_audio-${{ env.TAG }}-aarch64-unknown-linux-gnu.tar.gz.sha256
-          tag_name: ${{ env.TAG }}
+            nu_plugin_audio-${{ steps.resolve-tag.outputs.tag }}-aarch64-unknown-linux-gnu.tar.gz
+            nu_plugin_audio-${{ steps.resolve-tag.outputs.tag }}-aarch64-unknown-linux-gnu.tar.gz.sha256
+          tag_name: ${{ steps.resolve-tag.outputs.tag }}

--- a/.github/workflows/release-arm64.yml
+++ b/.github/workflows/release-arm64.yml
@@ -29,7 +29,11 @@ jobs:
           if [[ -n "${{ github.event.inputs.tag }}" ]]; then
             TAG="${{ github.event.inputs.tag }}"
           else
-            TAG=$(gh api "repos/${{ github.repository }}/releases/latest" --jq '.tag_name')
+            TAG=$(gh api "repos/${{ github.repository }}/releases?per_page=1" --jq '.[0].tag_name // empty')
+            if [[ -z "$TAG" ]]; then
+              echo "Error: Could not resolve release tag from API"
+              exit 1
+            fi
           fi
           if [[ ! "$TAG" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$ ]]; then
             echo "Error: Invalid tag format"

--- a/.github/workflows/release-arm64.yml
+++ b/.github/workflows/release-arm64.yml
@@ -25,13 +25,17 @@ jobs:
     steps:
       - name: Resolve and validate tag
         id: resolve-tag
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag || '' }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          if [[ -n "${{ github.event.inputs.tag }}" ]]; then
-            TAG="${{ github.event.inputs.tag }}"
+          if [[ -n "$INPUT_TAG" ]]; then
+            TAG="$INPUT_TAG"
           else
-            TAG=$(gh api "repos/${{ github.repository }}/releases?per_page=1" --jq '.[0].tag_name // empty')
+            TAG=$(gh api "repos/${{ github.repository }}/releases?per_page=100" \
+              --jq "([.[] | select(.target_commitish == \"$HEAD_SHA\")][0].tag_name) // empty")
             if [[ -z "$TAG" ]]; then
-              echo "Error: Could not resolve release tag from API"
+              echo "Error: Could not resolve release tag for this workflow run"
               exit 1
             fi
           fi
@@ -39,7 +43,7 @@ jobs:
             echo "Error: Invalid tag format"
             exit 1
           fi
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          printf 'tag=%s\n' "$TAG" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ steps.resolve-tag.outputs.tag }}


### PR DESCRIPTION
### Problem

CodeQL flagged 7 critical alerts in `release-arm64.yml`:
- `actions/untrusted-checkout` — the workflow checked out code at a ref sourced from `workflow_run`
- `actions/code-injection` (×6) — `${{ env.TAG }}` was populated from `github.event.workflow_run.head_branch`, which is attacker-controlled

An attacker could create a branch named e.g. `v0.2.3; malicious-command` and trigger the release workflow, injecting into the tag resolution before validation ran.

### Fix

- Removes `TAG` from the job-level `env` block entirely
- Adds a dedicated `resolve-tag` step that sources the tag from two trusted inputs only:
  - `inputs.tag` for manual `workflow_dispatch` (privileged user input)
  - The GitHub releases API for `workflow_run` triggers (data the repo owns)
- Validation runs in the same step before the value is written to `$GITHUB_OUTPUT`
- All downstream references use `${{ steps.resolve-tag.outputs.tag }}` instead of `${{ env.TAG }}`

### Testing

- [ ] Trigger via `workflow_dispatch` with a valid tag — confirm build and upload succeed
- [ ] Confirm CodeQL alerts are resolved on next scan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release workflow: the pipeline now reliably determines and validates the release tag early, updates all downstream steps to use that resolved tag, and provides clearer logs and error handling. No end-user functional changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->