### PR TITLE
build: upgrade dependencies and bump to v0.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1127,9 +1127,9 @@ dependencies = [
 
 [[package]]
 name = "lofty"
-version = "0.23.3"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0c107dba5af049cf1c36b646fc1ba0cd2705f40d766d2c4c64f1b797c5fbed"
+checksum = "dec4feeff6c7d75093278133a06e827d7af6d2bfe20b0f331f9d10338a5ec7ca"
 dependencies = [
  "byteorder",
  "data-encoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1064,9 +1064,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.178"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libloading"
@@ -1106,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litrs"
@@ -1168,9 +1168,9 @@ dependencies = [
 
 [[package]]
 name = "lscolors"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61183da5de8ba09a58e330d55e5ea796539d8443bd00fdeb863eac39724aa4ab"
+checksum = "d60e266dfb1426eb2d24792602e041131fdc0236bb7007abc0e589acafd60929"
 dependencies = [
  "aho-corasick",
  "nu-ansi-term",
@@ -1284,9 +1284,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.30.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
@@ -1324,9 +1324,9 @@ dependencies = [
 
 [[package]]
 name = "nu-derive-value"
-version = "0.111.0"
+version = "0.112.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71958b54c367bda033f7dcc4a73b61972fb52323f71a1e3533e290fa67148d1"
+checksum = "cff9cc0f38dafabd4c4d5be41099f21161aa730ad28a1b48b0d64af9e85cb5b0"
 dependencies = [
  "heck",
  "proc-macro-error2",
@@ -1337,9 +1337,9 @@ dependencies = [
 
 [[package]]
 name = "nu-engine"
-version = "0.111.0"
+version = "0.112.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d41b3e3e2d25c30741a0761856258e22624c0d60064e4f0e12f86202a451d492"
+checksum = "21070daac55c85e7c6c608937d3747d4b239f48c111ef8697c9179e7f3832dfd"
 dependencies = [
  "fancy-regex",
  "log",
@@ -1352,9 +1352,9 @@ dependencies = [
 
 [[package]]
 name = "nu-experimental"
-version = "0.111.0"
+version = "0.112.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f328fa0531bdf49c2dc0312b40cb780e3d74e0d3dbb15d508469a5ae4cfd8d8f"
+checksum = "84546fe8f7c249acad1fc5796974b024204834b10e1fa7367bef445f51e4496f"
 dependencies = [
  "itertools 0.14.0",
  "thiserror 2.0.18",
@@ -1362,15 +1362,15 @@ dependencies = [
 
 [[package]]
 name = "nu-glob"
-version = "0.111.0"
+version = "0.112.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ee787f61353c9c90581ddf4c0602a07b991cdd06c97dac8b6d323a1a52c43a"
+checksum = "1e7df51b4cd88b3a2a97ca50565b0ddd9df54a1d6a4b65f95133754d6b3d3491"
 
 [[package]]
 name = "nu-path"
-version = "0.111.0"
+version = "0.112.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c01d110cb931acf56237ce572e5b156e8e1134227c90deeffb92eedda9482c23"
+checksum = "4889ef632f97913ae9bbadedf38559978e5aa2e1a485f895e635f9d6eb7b1282"
 dependencies = [
  "dirs",
  "omnipath",
@@ -1380,9 +1380,9 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin"
-version = "0.111.0"
+version = "0.112.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c322531b1a7d6338c5ead1f454294f46babf8c99cd4716311cab1e88ba52b154"
+checksum = "99151a87d60fc3478a783ac84122624e05f5d697fcc95e1ca65353e7fa731d5b"
 dependencies = [
  "log",
  "nix",
@@ -1396,14 +1396,15 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-core"
-version = "0.111.0"
+version = "0.112.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ee792aeb0d37e0ed55ca4304e434eece497914e27ae42616a8bb973f5d2720"
+checksum = "7c1153e12ed480e54908140cfbf728d2bcfc9fc5bf1cb2dd2fb4e00a34a4fa7d"
 dependencies = [
  "interprocess",
  "log",
  "nu-plugin-protocol",
  "nu-protocol",
+ "nu-utils",
  "rmp-serde",
  "serde",
  "serde_json",
@@ -1412,9 +1413,9 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-protocol"
-version = "0.111.0"
+version = "0.112.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7725f341428db16dbef4392970de32705abc77ee80a902572c8da811dade3564"
+checksum = "8fad023cf69f0436b404f04ab03da7e4b6f0ba9dffc54b219cf11a97db53f45a"
 dependencies = [
  "nu-protocol",
  "nu-utils",
@@ -1426,9 +1427,9 @@ dependencies = [
 
 [[package]]
 name = "nu-protocol"
-version = "0.111.0"
+version = "0.112.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c0e58cbeb46cbfd40156e6f4b9f90e4a77e774ca863fa158867a4726aab1d1"
+checksum = "6564173bad622e2353641cf45359326eeb421caf76580a16f03bc7d2480783a1"
 dependencies = [
  "brotli",
  "bytes",
@@ -1466,9 +1467,9 @@ dependencies = [
 
 [[package]]
 name = "nu-system"
-version = "0.111.0"
+version = "0.112.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62fe7847b65edbe362a0fcb67dedfab9fd7370e89c0313f7cb7d0a7ab8f9834b"
+checksum = "fd375e1a29716a5c88f3e3bd9fd65f49be82e80bfdb91be920fedce61d361b07"
 dependencies = [
  "chrono",
  "itertools 0.14.0",
@@ -1478,6 +1479,7 @@ dependencies = [
  "mach2 0.6.0",
  "nix",
  "ntapi",
+ "nu-utils",
  "procfs",
  "sysinfo",
  "uucore",
@@ -1487,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "nu-utils"
-version = "0.111.0"
+version = "0.112.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df85a8a4bb28c84d5f7c096c02c859ac454dfac59fd0296ab5eb6ed86619219e"
+checksum = "8eebd2ca48724174505d3349f458d0d0a3cb0d0474ec0a2c51b6e9a1ec7993ad"
 dependencies = [
  "byteyarn",
  "crossterm",
@@ -1501,16 +1503,18 @@ dependencies = [
  "memchr",
  "nix",
  "num-format",
+ "parking_lot",
  "serde",
  "serde_json",
  "strip-ansi-escapes",
  "sys-locale",
  "unicase",
+ "web-time",
 ]
 
 [[package]]
 name = "nu_plugin_audio"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "chrono",
  "crossterm",
@@ -2118,9 +2122,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags 2.11.0",
  "errno",
@@ -2774,9 +2778,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uucore"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b157ba598d7f7ed06f6dbc62999edb9d730b4d3fb58e503d8ad6d5fbe1e04391"
+checksum = "07d779636d827cde4100f0e65ff3fd23b0b1f1195055475c6e6813d425f30c8e"
 dependencies = [
  "clap",
  "fluent",
@@ -2785,6 +2789,8 @@ dependencies = [
  "libc",
  "nix",
  "os_display",
+ "rustc-hash",
+ "rustix",
  "thiserror 2.0.18",
  "unic-langid",
  "uucore_procs",
@@ -2793,9 +2799,9 @@ dependencies = [
 
 [[package]]
 name = "uucore_procs"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa291a52608ac5a2f8539e119666e021baa6b8c01f22f02ed201bbae54cbbc0"
+checksum = "da865e8a648b260dbd89fca76d0801995877ab27a4e259b6dec30ba9743b86ab"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,27 +71,12 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
-dependencies = [
- "anstyle",
- "anstyle-parse 0.2.7",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
- "anstyle-parse 1.0.0",
+ "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -104,15 +89,6 @@ name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
 
 [[package]]
 name = "anstyle-parse"
@@ -295,9 +271,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -391,7 +367,7 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream 1.0.0",
+ "anstream",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -437,9 +413,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "coreaudio-rs"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d15c3c3cee7c087938f7ad1c3098840b3ef1f1bdc7f6e496336c3b1e7a6f3914"
+checksum = "16dd574a72a021b90c7656c474ea31d11a2f0366a8eff574186e761e0b9e3586"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
@@ -602,9 +578,9 @@ dependencies = [
 
 [[package]]
 name = "doctest-file"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aac81fa3e28d21450aa4d2ac065992ba96a1d7303efbce51a95f4fd175b67562"
+checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
 
 [[package]]
 name = "document-features"
@@ -632,9 +608,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
  "regex",
@@ -642,11 +618,11 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
- "anstream 0.6.21",
+ "anstream",
  "anstyle",
  "env_filter",
  "jiff",
@@ -846,6 +822,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -895,12 +877,12 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -939,9 +921,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "009ae045c87e7082cb72dab0ccd01ae075dd00141ddc108f43a0ea150a9e7227"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
 ]
@@ -978,9 +960,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
@@ -1015,7 +997,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -1024,16 +1006,40 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1046,14 +1052,14 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lean_string"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4deb1a7e906e1587ab20848215f09e1bd6dee902aca914abf439d511320c4339"
+checksum = "8a262b6ae1dd9c2d3cf7977a816578b03bf8fb60b61545c395880f95eefc5b24"
 dependencies = [
  "castaway",
  "itoa",
  "ryu",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1097,9 +1103,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
 ]
@@ -1243,9 +1249,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
@@ -1260,7 +1266,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
  "bitflags 2.11.0",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "ndk-sys",
  "num_enum",
@@ -1279,7 +1285,7 @@ version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
- "jni-sys",
+ "jni-sys 0.3.1",
 ]
 
 [[package]]
@@ -1599,9 +1605,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -1609,9 +1615,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1813,9 +1819,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
@@ -1948,9 +1954,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -1959,9 +1965,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
@@ -2093,9 +2099,9 @@ checksum = "7204ed6420f698836b76d4d5c2ec5dec7585fd5c3a788fd1cde855d1de598239"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -2168,9 +2174,9 @@ checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2254,9 +2260,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -2562,12 +2568,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2622,9 +2628,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "serde_core",
@@ -2633,18 +2639,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.4+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -2654,9 +2660,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
@@ -2748,9 +2754,9 @@ checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
@@ -2852,9 +2858,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2865,23 +2871,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2889,9 +2891,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2902,9 +2904,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -2945,9 +2947,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3130,15 +3132,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -3170,28 +3163,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -3216,12 +3192,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3232,12 +3202,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3252,22 +3216,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3282,12 +3234,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3298,12 +3244,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3318,12 +3258,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3336,16 +3270,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]
@@ -3461,15 +3389,15 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "serde",
  "zerofrom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nu_plugin_audio"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 description = "A nushell plugin to make and play sounds"
 homepage = "https://github.com/SuaveIV/nu_plugin_audio"
@@ -27,10 +27,10 @@ log = "0.4"
 version = "0.29"
 
 [dependencies.nu-plugin]
-version = "0.111.0"
+version = "0.112.0"
 
 [dependencies.nu-protocol]
-version = "0.111.0"
+version = "0.112.0"
 features = ["plugin"]
 
 [dependencies.rodio]
@@ -41,7 +41,7 @@ default-features = false
 version = "0.2"
 
 [dependencies.lofty]
-version = "0.23"
+version = "0.24"
 
 [features]
 default = [

--- a/build.nu
+++ b/build.nu
@@ -86,7 +86,7 @@ def download_and_install [
         let expected = if ($expected_checksum != null) {
             $expected_checksum
         } else if ($checksum_url != null) {
-            try { http get $checksum_url | str trim } catch {
+            try { http-get-with-retry $checksum_url | str trim } catch {
                 log warning $"failed to fetch checksum from ($checksum_url)"
                 try { rm --recursive --force $tmp_dir }
                 return false

--- a/build.nu
+++ b/build.nu
@@ -127,14 +127,10 @@ def download_and_install [
     log info extracting...
     let extract_ok: bool = try {
         if ($filename | str ends-with .zip) {
-            try {
-                (tar --extract --file $archive_path --directory $tmp_dir | complete).exit_code == 0
-            } catch {
-                if ($nu.os-info.name == windows) {
-                    (powershell -c $"Expand-Archive -Path '($archive_path)' -DestinationPath '($tmp_dir)' -Force" | complete).exit_code == 0
-                } else {
-                    (unzip -o $archive_path -d $tmp_dir | complete).exit_code == 0
-                }
+            if ($nu.os-info.name == windows) {
+                (powershell -c $"Expand-Archive -Path '($archive_path)' -DestinationPath '($tmp_dir)' -Force" | complete).exit_code == 0
+            } else {
+                (unzip -o $archive_path -d $tmp_dir | complete).exit_code == 0
             }
         } else if ($filename | str ends-with .tar.xz) {
             # Use tar's built-in xz support (--xz / -J) to avoid losing the
@@ -192,11 +188,15 @@ def check_and_download_prebuilt [
     try {
         http head $url
 
-        # Conditionally pass optional flags only when not null
+        # Conditionally pass optional flags for all combinations
         if ($filename != null) and ($install_root != null) and ($checksum_url != null) {
             download_and_install $url $name --filename $filename --install-root $install_root --checksum-url $checksum_url
         } else if ($filename != null) and ($install_root != null) {
             download_and_install $url $name --filename $filename --install-root $install_root
+        } else if ($filename != null) and ($checksum_url != null) {
+            download_and_install $url $name --filename $filename --checksum-url $checksum_url
+        } else if ($install_root != null) and ($checksum_url != null) {
+            download_and_install $url $name --install-root $install_root --checksum-url $checksum_url
         } else if ($filename != null) {
             download_and_install $url $name --filename $filename
         } else if ($install_root != null) {

--- a/build.nu
+++ b/build.nu
@@ -1,10 +1,11 @@
 use std log
 
-def http-get-with-retry [
+# Fetch a URL with automatic retries on failure.
+def http-get-with-retry [ # nu-lint-ignore: missing_output_type
     url: string
-    max_retries: int = 3
-    timeout: duration = 10sec
-]: nothing -> any {
+    --max-retries (-r): int = 3  # number of attempts before giving up
+    --timeout (-t): duration = 10sec  # per-attempt timeout
+] {
     mut last_err = null
     for attempt in 1..$max_retries {
         let err = try {
@@ -22,6 +23,7 @@ def http-get-with-retry [
         help: ($last_err | get msg? | default "unknown error")
     }
 }
+
 let features = [
     flac
     minimp3
@@ -35,35 +37,43 @@ let features = [
     wav
 ]
 
-def detect_target [] {
+# Return the Rust target triple for the current platform.
+# Errors on unsupported platforms (caller should use try/catch).
+def detect_target []: nothing -> string {
     let os = $nu.os-info.name
     let arch = $nu.os-info.arch
 
-    match [$os, $arch] {
+    match [$os $arch] {
         ["linux", "x86_64"] => "x86_64-unknown-linux-gnu",
         ["linux", "aarch64"] => "aarch64-unknown-linux-gnu",
         ["macos", "x86_64"] => "x86_64-apple-darwin",
         ["macos", "aarch64"] => "aarch64-apple-darwin",
         ["windows", "x86_64"] => "x86_64-pc-windows-msvc",
-        _ => null
+        _ => { error make {msg: $"unsupported platform: ($os)/($arch)"} }
     }
 }
 
+# Download a release archive, verify its checksum (or GPG signature), extract
+# it, and copy the named binary into <install-root>/bin/.  Returns true on
+# success, false on any recoverable failure.
 def download_and_install [
-    url: string
-    filename: string
-    install_root: path
-    name: string
-    checksum_url?: string
-    expected_checksum?: string
-    signature_path?: string
-] {
+    url: string       # URL of the release archive
+    name: string      # binary name to locate inside the extracted archive
+    --filename (-f): path     # archive filename (derived from URL basename if omitted)
+    --install-root (-i): path # destination root; defaults to $env.NUPM_HOME/plugins
+    --checksum-url (-c): string        # URL of a .sha256 file to verify against
+    --expected-checksum (-e): string   # inline expected hash (sha256 or md5)
+    --signature-path (-s): path        # path to a detached GPG signature
+]: nothing -> bool {
+    let filename = if ($filename == null) { $url | path basename } else { $filename }
+    let install_root = if ($install_root == null) { $env.NUPM_HOME | path join "plugins" } else { $install_root }
+
     log info $"downloading prebuilt binary..."
-    let tmp_dir = (mktemp -d)
-    let archive_path = $tmp_dir | path join $filename
+    let tmp_dir = (mktemp --directory)
+    let archive_path = ($tmp_dir | path join $filename)
 
     try {
-        http-get-with-retry $url 3 30sec | save $archive_path
+        http-get-with-retry $url --timeout 30sec | save $archive_path
     } catch {
         log warning "failed to download artifact"
         return false
@@ -72,11 +82,11 @@ def download_and_install [
     let gpg_available = (which gpg | is-not-empty)
 
     if ($signature_path != null) and $gpg_available {
-        try {
-            gpg --verify $signature_path $archive_path
-        } catch {
+        # Use | complete so we get the exit code without pipefail aborting the script.
+        let result = (gpg --verify $signature_path $archive_path | complete)
+        if $result.exit_code != 0 {
             log warning "gpg signature verification failed"
-            rm -rf $tmp_dir
+            try { rm --recursive --force $tmp_dir }
             return false
         }
     } else {
@@ -84,150 +94,193 @@ def download_and_install [
             $expected_checksum
         } else if ($checksum_url != null) {
             try { http get $checksum_url | str trim } catch { null }
+        } else {
+            null
         }
 
         if ($expected != null) {
             let is_md5 = ($expected | str length) == 32
-            let actual = if $is_md5 {
-                open $archive_path | hash md5
-            } else {
-                open $archive_path | hash sha256
+            let actual = try {
+                if $is_md5 {
+                    open $archive_path | hash md5
+                } else {
+                    open $archive_path | hash sha256
+                }
+            } catch {
+                log warning "failed to read archive for checksum"
+                try { rm --recursive --force $tmp_dir }
+                return false
             }
 
             # sha256sum files are "<hash>  <filename>" — extract just the hash
             let actual_hash = ($actual | str trim)
-            let expected_hash = ($expected | str trim | split row " " | first)
+            let expected_hash = ($expected | str trim | split words | first)
 
             if $actual_hash != $expected_hash {
                 log warning $"checksum mismatch: expected ($expected_hash), got ($actual_hash)"
-                rm -rf $tmp_dir
+                try { rm --recursive --force $tmp_dir }
                 return false
             }
         }
     }
 
-    log info "extracting..."
-    try {
-        if ($filename | str ends-with ".zip") {
+    log info extracting...
+    let extract_ok: bool = try {
+        if ($filename | str ends-with .zip) {
             try {
-                ^tar -xf $archive_path -C $tmp_dir
+                (tar --extract --file $archive_path --directory $tmp_dir | complete).exit_code == 0
             } catch {
-                if ($nu.os-info.name == "windows") {
-                    ^powershell -c $"Expand-Archive -Path '($archive_path)' -DestinationPath '($tmp_dir)' -Force"
+                if ($nu.os-info.name == windows) {
+                    (powershell -c $"Expand-Archive -Path '($archive_path)' -DestinationPath '($tmp_dir)' -Force" | complete).exit_code == 0
                 } else {
-                    ^unzip -o $archive_path -d $tmp_dir
+                    (unzip -o $archive_path -d $tmp_dir | complete).exit_code == 0
                 }
             }
-        } else if ($filename | str ends-with ".tar.xz") {
-            try {
-                ^xz -dc $archive_path | ^tar -xf - -C $tmp_dir
-            } catch {
-                ^tar -xf $archive_path -C $tmp_dir
-            }
+        } else if ($filename | str ends-with .tar.xz) {
+            # Use tar's built-in xz support (--xz / -J) to avoid losing the
+            # intermediate exit code that the old `^xz | ^tar` pipeline silently swallowed.
+            (tar --extract --xz --file $archive_path --directory $tmp_dir | complete).exit_code == 0
         } else {
-            ^tar -xf $archive_path -C $tmp_dir
+            (tar --extract --file $archive_path --directory $tmp_dir | complete).exit_code == 0
         }
     } catch {
+        false
+    }
+
+    if not $extract_ok {
         log warning "failed to extract artifact"
+        try { rm --recursive --force $tmp_dir }
         return false
     }
 
-    let bin_name = if $nu.os-info.name == "windows" { $"($name).exe" } else { $name }
+    let bin_name = if $nu.os-info.name == windows { $"($name).exe" } else { $name }
     let found = (glob ($tmp_dir | path join "**" $bin_name))
 
     if ($found | is-empty) {
         log warning $"binary ($bin_name) not found in archive"
+        try { rm --recursive --force $tmp_dir }
         return false
     }
 
     let extracted_bin = ($found | first)
-    let bin_dir = $install_root | path join "bin"
-    mkdir $bin_dir
-    let dest_path = $bin_dir | path join $bin_name
+    let bin_dir = ($install_root | path join bin)
+    try { mkdir $bin_dir }
+    let dest_path = ($bin_dir | path join $bin_name)
 
-    cp -f $extracted_bin $dest_path
-    rm -rf $tmp_dir
+    try {
+        cp --force $extracted_bin $dest_path
+    } catch {
+        log warning $"failed to copy binary to ($dest_path)"
+        try { rm --recursive --force $tmp_dir }
+        return false
+    }
+    try { rm --recursive --force $tmp_dir }
 
     log info $"installed prebuilt binary to ($dest_path)"
-    return true
+    true
 }
 
+# HEAD-check a URL then delegate to download_and_install.
+# Returns false immediately if the release asset does not exist.
 def check_and_download_prebuilt [
     url: string
-    filename: string
-    install_root: path
     name: string
-    checksum_url?: string
-] {
+    --filename (-f): path
+    --install-root (-i): path
+    --checksum-url (-c): string
+]: nothing -> bool {
     try {
         http head $url
-        return (download_and_install $url $filename $install_root $name $checksum_url)
+
+        # Conditionally pass optional flags only when not null
+        if ($filename != null) and ($install_root != null) and ($checksum_url != null) {
+            download_and_install $url $name --filename $filename --install-root $install_root --checksum-url $checksum_url
+        } else if ($filename != null) and ($install_root != null) {
+            download_and_install $url $name --filename $filename --install-root $install_root
+        } else if ($filename != null) {
+            download_and_install $url $name --filename $filename
+        } else if ($install_root != null) {
+            download_and_install $url $name --install-root $install_root
+        } else if ($checksum_url != null) {
+            download_and_install $url $name --checksum-url $checksum_url
+        } else {
+            download_and_install $url $name
+        }
     } catch {
         log warning "prebuilt binary not found on GitHub releases, falling back to source build"
-        return false
+        false
     }
 }
 
+# Try to install a prebuilt release binary for the current platform.
+# Returns true when a binary was successfully installed, false otherwise.
 def install_prebuilt [
-    repo_root: path,
-    install_root: path,
-    name: string,
+    name: string
     version: string
-] {
-    let target = detect_target
-    if $target == null {
+    --install-root (-i): path  # defaults to $env.NUPM_HOME/plugins
+]: nothing -> bool {
+    let install_root = if ($install_root == null) { $env.NUPM_HOME | path join plugins } else { $install_root }
+
+    # detect_target errors on unknown platforms; treat that as "no prebuilt available".
+    let target = try { detect_target } catch {
         log warning "prebuilt binary not available for this platform, falling back to source build"
         return false
     }
 
-    let ext = if $nu.os-info.name == "windows" { "zip" } else { "tar.gz" }
+    let ext = if $nu.os-info.name == windows { "zip" } else { "tar.gz" }
     let filename = $"($name)-v($version)-($target).($ext)"
     let url = $"https://github.com/SuaveIV/($name)/releases/download/v($version)/($filename)"
     let checksum_url = $"($url).sha256"
 
     log info $"checking for prebuilt binary at ($url)"
 
-    if (check_and_download_prebuilt $url $filename $install_root $name $checksum_url) {
+    if (check_and_download_prebuilt $url $name --filename $filename --install-root $install_root --checksum-url $checksum_url) {
         return true
     }
 
-    # Try alternative extensions if tar.gz failed
-    if $ext == "tar.gz" {
-        let ext_xz = "tar.xz"
-        let filename_xz = $"($name)-v($version)-($target).($ext_xz)"
+    # Try .tar.xz as a fallback if .tar.gz was not found.
+    if $ext == tar.gz {
+        let filename_xz = $"($name)-v($version)-($target).tar.xz"
         let url_xz = $"https://github.com/SuaveIV/($name)/releases/download/v($version)/($filename_xz)"
         let checksum_url_xz = $"($url_xz).sha256"
         log info $"checking for prebuilt binary at ($url_xz)"
 
-        if (check_and_download_prebuilt $url_xz $filename_xz $install_root $name $checksum_url_xz) {
+        if (check_and_download_prebuilt $url_xz $name --filename $filename_xz --install-root $install_root --checksum-url $checksum_url_xz) {
             return true
         }
     }
 
-    return false
+    false
 }
 
-def main [package_file: path = nupm.nuon] {
-    let repo_root = (ls -f $package_file | first | get name | path dirname)
-    let install_root = $env.NUPM_HOME | path join "plugins"
+def main [package_file: path = nupm.nuon]: nothing -> nothing {
+    let repo_root = try {
+        ls --full-paths $package_file | first | get name | path dirname
+    } catch {
+        error make {msg: $"Cannot open package file: ($package_file)"}
+    }
+    let install_root = $env.NUPM_HOME | path join plugins
 
-    let cargo = open ($repo_root | path join "Cargo.toml")
+    let cargo = try {
+        open ($repo_root | path join Cargo.toml)
+    } catch {
+        error make {msg: "Cannot open Cargo.toml"}
+    }
     let name = $cargo.package.name
     let version = $cargo.package.version
 
-    if (install_prebuilt $repo_root $install_root $name $version) {
-        let ext: string = if ($nu.os-info.name == 'windows') { '.exe' } else { '' }
-        plugin add $"($install_root | path join "bin" $name)($ext)"
+    if (install_prebuilt $name $version --install-root $install_root) {
+        let ext: string = if ($nu.os-info.name == windows) { ".exe" } else { "" }
+        plugin add $"($install_root | path join bin $name)($ext)"
         log info "do not forget to restart Nushell for the plugin to be fully available!"
         return
     }
 
-    let features = $features | input list --multi "select cargo features"
-
-    let cmd = $"cargo install --path '($repo_root)' --root '($install_root)' --features=($features | str join ",")"
-    log info $"building plugin using: (ansi blue)($cmd)(ansi reset)"
-    nu -c $cmd
-    let ext: string = if ($nu.os-info.name == 'windows') { '.exe' } else { '' }
-    plugin add $"($install_root | path join "bin" $name)($ext)"
+    let selected_features = $features | input list --multi "select cargo features"
+    let feature_list = ($selected_features | str join ,)
+    log info $"building plugin using: (ansi blue)cargo install --path ($repo_root) --root ($install_root) --features=($feature_list)(ansi reset)"
+    cargo install --path $repo_root --root $install_root $"--features=($feature_list)"
+    let ext: string = if ($nu.os-info.name == windows) { ".exe" } else { "" }
+    plugin add $"($install_root | path join bin $name)($ext)"
     log info "do not forget to restart Nushell for the plugin to be fully available!"
 }

--- a/build.nu
+++ b/build.nu
@@ -25,16 +25,9 @@ def http-get-with-retry [ # nu-lint-ignore: missing_output_type
 }
 
 let features = [
-    flac
-    minimp3
-    symphonia-aac
-    symphonia-flac
-    symphonia-isomp4
-    symphonia-mp3
-    symphonia-vorbis
-    symphonia-wav
-    vorbis
-    wav
+    default
+    lite
+    all-decoders
 ]
 
 # Return the Rust target triple for the current platform.
@@ -93,7 +86,11 @@ def download_and_install [
         let expected = if ($expected_checksum != null) {
             $expected_checksum
         } else if ($checksum_url != null) {
-            try { http get $checksum_url | str trim } catch { null }
+            try { http get $checksum_url | str trim } catch {
+                log warning $"failed to fetch checksum from ($checksum_url)"
+                try { rm --recursive --force $tmp_dir }
+                return false
+            }
         } else {
             null
         }

--- a/nupm.nuon
+++ b/nupm.nuon
@@ -1,1 +1,1 @@
-{name: nu_plugin_audio, version: "0.2.1", description: "A nushell plugin to make and play sounds", license: LICENSE, type: custom}
+{name: nu_plugin_audio, version: "0.2.4", description: "A nushell plugin to make and play sounds", license: LICENSE, type: custom}


### PR DESCRIPTION
This PR upgrades dependencies and fixes code quality issues in build.nu.

## What changed

We updated Nushell plugin dependencies from 0.111.0 to 0.112.0, along with system libraries like libc, nix, linux-raw-sys, and lscolors. The build script was refactored to use named flags instead of positional parameters, making it clearer and easier to maintain.

## Fixes

- Removed vague 'any' type annotation from http-get-with-retry
- Added proper null checks for optional typed flags
- Fixed ZIP extraction to avoid unnecessary tar attempts
- Fixed conditional chain for flag combinations to handle all cases

## Dependencies

Incorporated the lofty 0.24 update from dependabot, which fixes FLAC metadata corruption and improves APE tag handling for multi-value items.

## Testing

Build script tested on the current branch and handles all extraction formats correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Released version 0.2.4 with dependency updates.
  * Updated Nushell plugin framework and protocol libraries for compatibility.
  * Updated audio decoding library to the latest version.

* **Bug Fixes**
  * Improved error handling and validation in the build and installation process.
  * Enhanced platform detection with clearer error messages for unsupported systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->