### PR TITLE
chore: upgrade Nushell to 0.114.1 and update cargo-dist release config

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,9 @@ jobs:
           submodules: recursive
 
       - name: Install ALSA dev dependency
-        run: sudo apt-get install -y libasound2-dev pkg-config
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libasound2-dev pkg-config
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,7 +148,7 @@ jobs:
           dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
           echo "dist ran successfully"
       - name: Attest
-        uses: actions/attest@075d9d9f58257041a6701b2a939e6a048a1c93a0
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763
         with:
           subject-path: "target/distrib/*${{ join(matrix.targets, ', ') }}*"
       - id: cargo-dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.32.0/cargo-dist-installer.sh | sh"
       - name: Cache dist
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
@@ -148,7 +148,7 @@ jobs:
           dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
           echo "dist ran successfully"
       - name: Attest
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373
+        uses: actions/attest@075d9d9f58257041a6701b2a939e6a048a1c93a0
         with:
           subject-path: "target/distrib/*${{ join(matrix.targets, ', ') }}*"
       - id: cargo-dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,16 @@
 /target
-.vscode
+.vscode/
+
+# Python / uv virtual environments
+.venv/
+venv/
+
+# Backup and log files
+**/*.rs.bk
+*.log
 
 # Temp files
-./tmp
-./temp
+tmp/
+temp/
 .agents/
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1367,9 +1367,9 @@ dependencies = [
 
 [[package]]
 name = "nu-derive-value"
-version = "0.114.0"
+version = "0.114.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16deb398cda4364cbba0dc06fe21876e3f9abc05e39b5c5dd31824248edcdf34"
+checksum = "be1341b1e7a6f84f5e6ab003a49efc8a90e480c74cc18c5c90b5461b2fbc17f8"
 dependencies = [
  "heck",
  "proc-macro-error2",
@@ -1380,9 +1380,9 @@ dependencies = [
 
 [[package]]
 name = "nu-engine"
-version = "0.114.0"
+version = "0.114.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a87d13dfbbe72bd30ea13c5514b96648605c76ffb18b48dbdb3835e7db82101"
+checksum = "7dabd15b72caf0a2b226251703b5126a7429d10198f643ace850692f3fd24c1e"
 dependencies = [
  "fancy-regex",
  "log",
@@ -1395,9 +1395,9 @@ dependencies = [
 
 [[package]]
 name = "nu-experimental"
-version = "0.114.0"
+version = "0.114.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c4906d5dfdda52b1139d67d6917593c48dc4020f0e5ad8c9011b2540cbca953"
+checksum = "d77602508caba97599c3f2a5a58f5b532fab15a5b2c74bdeb26c1f151fe842c5"
 dependencies = [
  "itertools 0.15.0",
  "thiserror 2.0.18",
@@ -1405,9 +1405,9 @@ dependencies = [
 
 [[package]]
 name = "nu-glob"
-version = "0.114.0"
+version = "0.114.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a20ceb7acd84831cf1ba44096e450837af7caee727276f63eb335b559d8b293"
+checksum = "0b31d6cdcb4fa6d0513fc0d82a174967b6aeb822fbfd4f1b5ce8519fe5f67c95"
 dependencies = [
  "anyhow",
  "log",
@@ -1417,9 +1417,9 @@ dependencies = [
 
 [[package]]
 name = "nu-path"
-version = "0.114.0"
+version = "0.114.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bbe9b67faa8959a194a302e870e915072d457efaf77c066eacc538f4e25bb41"
+checksum = "4fa6e1b44c9f9df11f7479b1db28a957c6ccc4414589f8712f3bad3842ade840"
 dependencies = [
  "dirs",
  "omnipath",
@@ -1429,9 +1429,9 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin"
-version = "0.114.0"
+version = "0.114.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c40cbf5d519187ad74e99f972b5aea74c13b72fdd711aecf8e81e9228376a5d"
+checksum = "e854feab2d721d3123e4b12b58134d965658045cb9faba3d03a321bec9ce25a4"
 dependencies = [
  "log",
  "nix",
@@ -1445,9 +1445,9 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-core"
-version = "0.114.0"
+version = "0.114.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b07f5a94d6a3e9e2eb77b378c78245c271fc6794191cfa11161dfeda2f82f85"
+checksum = "66f121197a0a06a5231bc023bdebefd7fd58e034b86f72c46e9ccd038fee3054"
 dependencies = [
  "interprocess",
  "log",
@@ -1462,9 +1462,9 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-protocol"
-version = "0.114.0"
+version = "0.114.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96907c688bea3579a65a4b8462761a8f12762627ffa0666071bc4f5aa1617f6"
+checksum = "db1deef5bf869a03a80d668e8a474a734edafc21c3a8e91e2f7f0fd45042fc4f"
 dependencies = [
  "nu-protocol",
  "nu-utils",
@@ -1476,9 +1476,9 @@ dependencies = [
 
 [[package]]
 name = "nu-protocol"
-version = "0.114.0"
+version = "0.114.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1197a66b4839ceeedb3c57bd93e788e8c5b7584dcc541749f4640b4644b801c8"
+checksum = "4f44d325b0859551a05341666d94ab5b2173803960b044d7600c25425d629183"
 dependencies = [
  "brotli",
  "bstr",
@@ -1521,9 +1521,9 @@ dependencies = [
 
 [[package]]
 name = "nu-system"
-version = "0.114.0"
+version = "0.114.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08ce203bcb556aeedfe0b7ab3eecfee4b802e01a103e9a85b427347f66a6f67"
+checksum = "5a41ebfa02bc180544f8c895b715077b3e77c642e13a3ae7644f887b077fae99"
 dependencies = [
  "chrono",
  "itertools 0.15.0",
@@ -1543,9 +1543,9 @@ dependencies = [
 
 [[package]]
 name = "nu-utils"
-version = "0.114.0"
+version = "0.114.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e434826a472a7178517c01a655f844022c76d991eb66dc16ac4476203c10234f"
+checksum = "322ee47417187b708bf89450a69fcddb8058559268d6a5e0cf0dc4afe7ba71aa"
 dependencies = [
  "byteyarn",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,16 +3,16 @@ name = "nu_plugin_audio"
 version = "0.2.9"
 edition = "2021"
 description = "A nushell plugin to make and play sounds"
+readme = "README.md"
 homepage = "https://github.com/SuaveIV/nu_plugin_audio"
 repository = "https://github.com/SuaveIV/nu_plugin_audio"
-readme = "README.md"
 license = "MIT"
 keywords = [
-    "nushell",
-    "audio",
-    "mp3",
-    "player",
-    "plugin",
+  "audio",
+  "mp3",
+  "nushell",
+  "player",
+  "plugin",
 ]
 
 [package.metadata]
@@ -26,11 +26,14 @@ log = "0.4"
 [dependencies.crossterm]
 version = "0.29"
 
+[dependencies.lofty]
+version = "0.24"
+
 [dependencies.nu-plugin]
-version = "0.114.0"
+version = "0.114.1"
 
 [dependencies.nu-protocol]
-version = "0.114.0"
+version = "0.114.1"
 features = ["plugin"]
 
 [dependencies.rodio]
@@ -40,37 +43,34 @@ default-features = false
 [dependencies.unicode-width]
 version = "0.2"
 
-[dependencies.lofty]
-version = "0.24"
-
 [features]
 default = [
-    "rodio/playback",
-    "rodio/symphonia-all",
-    "rodio/dither",
-    "rodio/symphonia-simd",
-    "rodio/64bit",
-    "rodio/recording",
-    "rodio/wav_output",
-    "rodio/experimental",
+  "rodio/64bit",
+  "rodio/dither",
+  "rodio/experimental",
+  "rodio/playback",
+  "rodio/recording",
+  "rodio/symphonia-all",
+  "rodio/symphonia-simd",
+  "rodio/wav_output",
 ]
 
 lite = [
-    "rodio/playback",
-    "rodio/flac",
-    "rodio/vorbis",
-    "rodio/wav",
-    "rodio/symphonia-mp3",
+  "rodio/flac",
+  "rodio/playback",
+  "rodio/symphonia-mp3",
+  "rodio/vorbis",
+  "rodio/wav",
 ]
 
 # Retained as an alias for backwards compatibility
 all-decoders = ["default"]
 
 [profile.release]
-codegen-units = 1
-lto = true
 opt-level = 2
 strip = true
+lto = true
+codegen-units = 1
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,6 +1,6 @@
 [target.aarch64-unknown-linux-gnu]
 pre-build = [
-    "dpkg --add-architecture arm64",
-    "apt-get update",
-    "apt-get install -y --no-install-recommends libasound2-dev:arm64 pkg-config",
+  "dpkg --add-architecture arm64",
+  "apt-get update",
+  "apt-get install -y --no-install-recommends libasound2-dev:arm64 pkg-config",
 ]

--- a/Justfile
+++ b/Justfile
@@ -14,11 +14,21 @@ test-shell:
 check:
     -^cargo fmt --check
     -^cargo clippy
+    -just check-toml
+
+# check TOML formatting with tombi
+check-toml:
+    ^tombi check Cargo.toml dist-workspace.toml Cross.toml rust-toolchain.toml
+
+# format TOML files with tombi
+format-toml:
+    ^tombi format Cargo.toml dist-workspace.toml Cross.toml rust-toolchain.toml
 
 # fix clippy warnings and format
 fix:
     ^cargo clippy --fix --allow-dirty
     ^cargo fmt
+    just format-toml
 
 # build (default features)
 build:

--- a/Justfile
+++ b/Justfile
@@ -18,7 +18,7 @@ check:
 
 # check TOML formatting with tombi
 check-toml:
-    ^tombi check Cargo.toml dist-workspace.toml Cross.toml rust-toolchain.toml
+    ^tombi lint Cargo.toml dist-workspace.toml Cross.toml rust-toolchain.toml
 
 # format TOML files with tombi
 format-toml:

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -12,6 +12,9 @@ ci = "github"
 # The installers to generate for each app
 installers = ["shell", "powershell"]
 # Target platforms to build apps for (Rust target-triple syntax)
+# NOTE: aarch64-unknown-linux-gnu is excluded here because ALSA dependencies prevent
+# cargo-dist cross-compilation. See .github/workflows/release-arm64.yml for the
+# workflow that builds and uploads the ARM64 artifact.
 targets = [
   "aarch64-apple-darwin",
   "x86_64-apple-darwin",
@@ -35,4 +38,4 @@ pkg-config = "*"
 "actions/upload-artifact" = "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
 "actions/download-artifact" = "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c"
 "actions/attest-build-provenance" = "0f67c3f4856b2e3261c31976d6725780e5e4c373"
-"actions/attest" = "075d9d9f58257041a6701b2a939e6a048a1c93a0"
+"actions/attest" = "a1948c3f048ba23858d222213b7c278aabede763"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -6,13 +6,18 @@ members = ["cargo:."]
 # Whether to enable GitHub Attestations
 github-attestations = true
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.31.0"
+cargo-dist-version = "0.32.0"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
 installers = ["shell", "powershell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+targets = [
+  "aarch64-apple-darwin",
+  "x86_64-apple-darwin",
+  "x86_64-unknown-linux-gnu",
+  "x86_64-pc-windows-msvc"
+]
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
 # Whether to install an updater program
@@ -30,4 +35,4 @@ pkg-config = "*"
 "actions/upload-artifact" = "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
 "actions/download-artifact" = "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c"
 "actions/attest-build-provenance" = "0f67c3f4856b2e3261c31976d6725780e5e4c373"
-
+"actions/attest" = "075d9d9f58257041a6701b2a939e6a048a1c93a0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,5 @@
 #:tombi schema.strict = false
+
 [toolchain]
 profile = "default"
 channel = "stable"


### PR DESCRIPTION
# PR: Upgrade Nushell, cargo-dist, and CI release workflows

This PR updates the Nushell dependencies and release configurations, fixes the attest action security pin, and adds TOML verification utilities.

## Changes

### 1. Cargo Dependencies
- Bumped `nu-plugin` and `nu-protocol` dependencies to v0.114.1.
- Updated `Cargo.lock` to lock these versions.

### 2. cargo-dist & CI Release Workflows
- Upgraded the local and preferred CI version of cargo-dist to v0.32.0.
- Pinned `actions/attest` in the release workflow to a verified commit SHA (`a1948c3f048ba23858d222213b7c278aabede763`).
- Added a comment in `dist-workspace.toml` explaining why `aarch64-unknown-linux-gnu` is built in a separate workflow (`release-arm64.yml`) due to ALSA cross-compilation limits.
- Regenerated the release workflow file (`release.yml`).

### 3. Developer Workflows & Ignores
- Added `check-toml` and `format-toml` recipes to the Justfile using `tombi lint` and `tombi format`.
- Configured `.gitignore` to exclude virtual environments (`.venv/`, `venv/`), cargo clippy backup files (`**/*.rs.bk`), and log files (`*.log`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Improvements**
  * Updated release tooling to improve package builds and artifact provenance verification.
  * Refreshed automated release workflows and supported build configuration.

* **Maintenance**
  * Updated core Nu plugin components to the latest patch release.
  * Added clearer project configuration checks and formatting support.
  * Expanded ignored development and temporary files to keep project artifacts clean.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->